### PR TITLE
Add `height` to prevent scaling issue in IE

### DIFF
--- a/src/index.cjsx
+++ b/src/index.cjsx
@@ -21,8 +21,10 @@ module.exports = (icons) ->
       styles = {
         fill: "currentcolor"
         verticalAlign: "middle"
-         # Use CSS instead of the width attr to support non-pixel units
+        # Use CSS instead of the width attr to support non-pixel units
         width: @props.size
+        # Prevents scaling issue in IE
+        height: @props.size
       }
 
       return (


### PR DESCRIPTION
For some reason, even if the `viewBox` attribute of the SVG defines a square area, if the height property is not set to be the same as the width, a large vertical whitespace is displayed in IE (even in recent versions).
