### PR TITLE
Fix unknown prop `fit` warning in React 15.3.0

### DIFF
--- a/src/index.cjsx
+++ b/src/index.cjsx
@@ -28,7 +28,7 @@ module.exports = (icons) ->
       }
 
       return (
-        <svg viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" fit
+        <svg viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet"
           style={objectAssign(
             styles,
             @props.style


### PR DESCRIPTION
I’m getting the following error in console when using React 15.3.0:

```
 Warning: Unknown prop `fit` on <svg> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
```

I’ve removed `fit` from the `svg` element in source which should solve the issue. Not sure what `fit` is supposed to do?
